### PR TITLE
Style

### DIFF
--- a/lib/style/background.dart
+++ b/lib/style/background.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'dart:ui';
-import 'app_colors.dart';
 
 class CircleBackground extends StatelessWidget {
   final Widget? child;
@@ -22,6 +21,8 @@ class CircleBackground extends StatelessWidget {
         return SizedBox.expand(
           child: Stack(
             children: [
+              // พื้นหลังขาวสุด
+              Container(color: Colors.white),
               // Left circle with Gaussian blur effect
               Positioned(
                 top: topOffset,

--- a/lib/style/background.dart
+++ b/lib/style/background.dart
@@ -21,7 +21,6 @@ class CircleBackground extends StatelessWidget {
         return SizedBox.expand(
           child: Stack(
             children: [
-              // พื้นหลังขาวสุด
               Container(color: Colors.white),
               // Left circle with Gaussian blur effect
               Positioned(


### PR DESCRIPTION
This pull request makes a minor update to the `CircleBackground` widget in `lib/style/background.dart`. The change ensures that the background is explicitly set to white before rendering other elements, which can help with visual consistency and layering.

* UI improvement:
  * Added a `Container` with a white background color at the bottom of the `Stack` in `CircleBackground`, ensuring the background is always white.

* Code cleanup:
  * Removed an unused import of `app_colors.dart` from `lib/style/background.dart`.